### PR TITLE
Fix training response includes model data

### DIFF
--- a/app/api/train/controllers/trainingController.ts
+++ b/app/api/train/controllers/trainingController.ts
@@ -56,6 +56,7 @@ export class TrainingController {
         modelId: trainingResult.modelId,
         metrics: trainingResult.metrics,
         history: trainingResult.history,
+        modelData: trainingResult.modelData,
         message: 'Modelo entrenado exitosamente'
       });
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -13,8 +13,6 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next";
-import { Inter, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
-
-const inter = Inter({
-  variable: "--font-inter",
-  subsets: ["latin"],
-});
-
-const jetbrainsMono = JetBrains_Mono({
-  variable: "--font-jetbrains-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Grocery ML Classifier",
@@ -24,9 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="es">
-      <body
-        className={`${inter.variable} ${jetbrainsMono.variable} antialiased bg-gray-50`}
-      >
+      <body className="antialiased bg-gray-50">
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- include model data in training POST response so the client can access model files
- use system fonts so Next.js build doesn't require network access

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68707ce5bbcc833294233561d9ffda5f