### PR TITLE
Add classify link in training header

### DIFF
--- a/app/train/components/TrainingHeader.tsx
+++ b/app/train/components/TrainingHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowLeft, User, Download } from 'lucide-react';
+import { ArrowLeft, User, Download, Zap } from 'lucide-react';
 import Link from 'next/link';
 
 interface TrainingHeaderProps {
@@ -21,7 +21,7 @@ export default function TrainingHeader({
   return (
     <div className="flex items-center justify-between mb-8">
       <div className="flex items-center space-x-4">
-        <Link 
+        <Link
           href="/"
           className="flex items-center space-x-2 text-gray-600 hover:text-blue-600 transition-colors"
         >
@@ -29,7 +29,15 @@ export default function TrainingHeader({
           <span>Volver al inicio</span>
         </Link>
         <div className="w-px h-6 bg-gray-300" />
-        <Link 
+        <Link
+          href="/classify"
+          className="flex items-center space-x-2 text-gray-600 hover:text-purple-600 transition-colors"
+        >
+          <Zap className="w-5 h-5" />
+          <span>Clasificar</span>
+        </Link>
+        <div className="w-px h-6 bg-gray-300" />
+        <Link
           href="/models"
           className="flex items-center space-x-2 text-gray-600 hover:text-green-600 transition-colors"
         >


### PR DESCRIPTION
## Summary
- add lucide icon import for `Zap`
- add link/button in training header to navigate to the classify page

## Testing
- `npm run lint` *(fails: Next.js ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_687846aa5e6083329912e9bb32989dee